### PR TITLE
Add Linux 5.1+ compat fix for deprecated CRYPTO_TFM_REQ_WEAK_KEY

### DIFF
--- a/gost28147_modes.c
+++ b/gost28147_modes.c
@@ -158,10 +158,13 @@ static int gost28147_cfb_encrypt_segment(struct skcipher_walk *walk,
 		gost28147_cfb_encrypt_one(ctx, iv, dst);
 		crypto_xor(dst, src, bsize);
 		memcpy(iv, dst, bsize);
+		iv = dst;
 
 		src += bsize;
 		dst += bsize;
 	} while ((nbytes -= bsize) >= bsize);
+
+	memcpy(walk->iv, iv, bsize);
 
 	return nbytes;
 }
@@ -272,7 +275,7 @@ static int gost28147_cfb_decrypt_inplace(struct skcipher_walk *walk,
 	const unsigned int bsize = GOST28147_BLOCK_SIZE;
 	unsigned int nbytes = walk->nbytes;
 	u8 *src = walk->src.virt.addr;
-	u8 *iv = walk->iv;
+	u8 *const iv = walk->iv;
 	u8 tmp[GOST28147_BLOCK_SIZE];
 
 	do {
@@ -281,8 +284,6 @@ static int gost28147_cfb_decrypt_inplace(struct skcipher_walk *walk,
 		crypto_xor(src, tmp, bsize);
 		src += bsize;
 	} while ((nbytes -= bsize) >= bsize);
-
-	memcpy(walk->iv, iv, bsize);
 
 	return nbytes;
 }


### PR DESCRIPTION
With Linux 5.1 onwards, CRYPTO_TFM_REQ_WEAK_KEY has been deprecated and
renamed to CRYPTO_TFM_REQ_FORBID_WEAK_KEYS.  Add a compat check to cater
for this change as introduced into Linux with commit 231baecdef7a9065799
("crypto: clarify name of WEAK_KEY request flag")

Signed-off-by: Colin Ian King <colin.king@canonical.com>