### PR TITLE
crypto: update crypto header and namespace

### DIFF
--- a/testmgr.c
+++ b/testmgr.c
@@ -35,6 +35,11 @@
 #include <crypto/kpp.h>
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+#include <crypto/internal/cipher.h>
+MODULE_IMPORT_NS(CRYPTO_INTERNAL);
+#endif
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
 #define CRYPTO_TFM_REQ_FORBID_WEAK_KEYS CRYPTO_TFM_REQ_WEAK_KEY
 #endif


### PR DESCRIPTION
Upstream:

commit 0eb76ba29d16df2951d37c54ca279c4e5630b071
Author: Ard Biesheuvel <ardb@kernel.org>
Date:   Fri Dec 11 13:27:15 2020 +0100

    crypto: remove cipher routines from public crypto API

moved crypto routines and definitions to an internal header and a
separate namespace, include them.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>